### PR TITLE
populate nav bar from global harp file

### DIFF
--- a/_harp.json
+++ b/_harp.json
@@ -5,6 +5,14 @@
      "href" : "https://chrome.google.com/webstore/detail/augury/elgalmkoelokbchhkhacckoklkejnhcd",
      "text" : "Install"
    },
+   "global_nav_pages": [{
+      "text": "Guides",
+      "href": "/guides/"
+      }, 
+      {
+      "text": "Resources",
+      "href": "/resources"
+    }],
     "resources": [
       {
         "title": "Augury, the New Angular 2 Debugging Tool & the Gov'ts Move to AngularJS",

--- a/index.ejs
+++ b/index.ejs
@@ -8,13 +8,7 @@
         text: 'Install',
         url: 'https://chrome.google.com/webstore/detail/augury/elgalmkoelokbchhkhacckoklkejnhcd'
       },
-      pages: [{
-        text: 'Guides',
-        href: '/guides/'
-      }, {
-        text: 'Resources',
-        href: '/resources'
-      }],
+      pages: global_nav_pages,
       homeHref: '/'
     }) %>
 


### PR DESCRIPTION
### Changes
* Nav bar will get page references

### Known issues
* Guides will not have this nav bar because `microsite-ui` needs to be updated to support the global nav pages key in `_harp.json`