### PR TITLE
use global nav branch on microsite-ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   "homepage": "https://github.com/rangle/augury.angular.io#readme",
   "dependencies": {
     "material-design-lite": "^1.1.3",
-    "microsite-ui": "git://github.com/angular/design-love.git"
+    "microsite-ui": "git://github.com/angular/design-love.git#feat-global-nav-ref"
   }
 }


### PR DESCRIPTION
### Changes
- use `feat-global-nav-ref` branch of `microsite-ui` until https://github.com/angular/design-love/pull/11 is merged. Once it is merged we can go back to master.
- The global nav is now visible in all parts of the site.
### Preview

<img width="1421" alt="screen shot 2016-08-10 at 11 35 37 am" src="https://cloud.githubusercontent.com/assets/1329167/17560053/959ffdce-5eee-11e6-9269-9f65922aa82e.png">
