### PR TITLE
fix hero alignment and font weight

### DIFF
--- a/src/pages/guides/_layout.ejs
+++ b/src/pages/guides/_layout.ejs
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="../../vendors/material-design-lite/material.min.css">
     <link rel="stylesheet" href="../../styles/main.css">
-    <link rel="stylesheet" href="styles/main.css">
+    <link rel="stylesheet" href="../styles/main.css">
 </head>
 <body class="mdl-demo mdl-base">
 <%- yield %>

--- a/src/pages/resources/_layout.ejs
+++ b/src/pages/resources/_layout.ejs
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="../../vendors/material-design-lite/material.min.css">
     <link rel="stylesheet" href="../../styles/main.css">
+    <link rel="stylesheet" href="../styles/main.css">
 </head>
 <body class="mdl-demo mdl-base">
 <%- yield %>

--- a/src/pages/resources/index.ejs
+++ b/src/pages/resources/index.ejs
@@ -14,7 +14,7 @@
     <main class="internal-page__content">
         <header class="hero-background">
             <header class="hero-background">
-                <section class="internal-header mdl-grid">
+                <section class="internal-header mdl-grid mdl-grid--no-spacing">
                     <div class="mdl-cell">
                         <h4 class="uppercase">&nbsp;Resources</h4>
                     </div>

--- a/src/pages/styles/main.scss
+++ b/src/pages/styles/main.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/theme';
+@import '../../styles/theme';
 
 //VARIABLES
 $body-padding-desktop: 48px;


### PR DESCRIPTION
The size of the hero, the font weight of the h4, and the left alignment of the h4 are now consistent.

![screen shot 2016-12-05 at 11 43 27 am](https://cloud.githubusercontent.com/assets/1329167/20893573/44489e9c-bae0-11e6-9a38-94c888466889.png)
![screen shot 2016-12-05 at 11 43 24 am](https://cloud.githubusercontent.com/assets/1329167/20893574/444a2cee-bae0-11e6-9faf-26458aabef30.png)
![screen shot 2016-12-05 at 11 43 23 am](https://cloud.githubusercontent.com/assets/1329167/20893576/444ab01a-bae0-11e6-958f-4c81ffcf1646.png)
![screen shot 2016-12-05 at 11 43 21 am](https://cloud.githubusercontent.com/assets/1329167/20893575/444a8e32-bae0-11e6-91a6-8f3f9183390f.png)
